### PR TITLE
MEN-4384 Management endpoints: set, get, remove key-value pairs.

### DIFF
--- a/api/http/internal.go
+++ b/api/http/internal.go
@@ -19,9 +19,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
 	"github.com/mendersoftware/go-lib-micro/identity"
 	"github.com/mendersoftware/go-lib-micro/rest.utils"
-	"github.com/pkg/errors"
 
 	"github.com/mendersoftware/deviceconfig/app"
 	"github.com/mendersoftware/deviceconfig/model"

--- a/api/http/management.go
+++ b/api/http/management.go
@@ -15,6 +15,16 @@
 package http
 
 import (
+	"github.com/mendersoftware/deviceconfig/model"
+	"github.com/mendersoftware/deviceconfig/store"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/mendersoftware/go-lib-micro/rest.utils"
+
 	"github.com/mendersoftware/deviceconfig/app"
 )
 
@@ -26,4 +36,83 @@ func NewManagementAPI(app app.App) *ManagementAPI {
 	return &ManagementAPI{
 		App: app,
 	}
+}
+
+func (api *ManagementAPI) SetConfiguration(c *gin.Context) {
+	var configuration model.Attributes
+
+	ctx := c.Request.Context()
+	devID, err := uuid.Parse(c.Param("device_id"))
+	if err != nil {
+		rest.RenderError(c,
+			http.StatusBadRequest,
+			errors.Wrap(err, "correctly formatted device id is needed"),
+		)
+		return
+	}
+
+	err = c.ShouldBindJSON(&configuration)
+	if err != nil {
+		rest.RenderError(c,
+			http.StatusBadRequest,
+			errors.Wrap(err, "malformed request body"),
+		)
+		return
+	}
+
+	for _, a := range configuration {
+		if err := a.Validate(); err != nil {
+			rest.RenderError(c,
+				http.StatusBadRequest,
+				errors.Wrap(err, "invalid request body"),
+			)
+			return
+		}
+	}
+
+	err = api.App.SetConfiguration(ctx, devID, configuration)
+	if err != nil {
+		c.Error(err) //nolint:errcheck
+		rest.RenderError(c,
+			http.StatusInternalServerError,
+			errors.New(http.StatusText(http.StatusInternalServerError)),
+		)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (api *ManagementAPI) GetConfiguration(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	devID, err := uuid.Parse(c.Param("device_id"))
+	if err != nil {
+		rest.RenderError(c,
+			http.StatusBadRequest,
+			errors.Wrap(err, "correctly formatted device id is needed"),
+		)
+		return
+	}
+
+	device, err := api.App.GetDevice(ctx, devID)
+	if err != nil {
+		switch cause := errors.Cause(err); cause {
+		case store.ErrDeviceNoExist:
+			c.Error(err) //nolint:errcheck
+			rest.RenderError(c,
+				http.StatusNotFound,
+				cause,
+			)
+			return
+		default:
+			c.Error(err) //nolint:errcheck
+			rest.RenderError(c,
+				http.StatusInternalServerError,
+				errors.New(http.StatusText(http.StatusInternalServerError)),
+			)
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, device)
 }

--- a/api/http/management_test.go
+++ b/api/http/management_test.go
@@ -1,0 +1,554 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/mendersoftware/deviceconfig/store"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	mapp "github.com/mendersoftware/deviceconfig/app/mocks"
+	"github.com/mendersoftware/deviceconfig/model"
+	"github.com/mendersoftware/go-lib-micro/rest.utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetConfiguration(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name string
+
+		TenantID string
+		Request  *http.Request
+
+		App    *mapp.App
+		Error  *rest.Error
+		Status int
+	}{
+		{
+			Name: "ok",
+
+			Request: func() *http.Request {
+				body, _ := json.Marshal(map[string]interface{}{
+					"key0": "value0",
+				})
+
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				app.On("SetConfiguration",
+					contextMatcher,
+					mock.AnythingOfType("uuid.UUID"),
+					model.Attributes{
+						{
+							Key:   "key0",
+							Value: "value0",
+						},
+					},
+				).Return(nil)
+				return app
+			}(),
+			Status: http.StatusNoContent,
+		},
+
+		{
+			Name: "error from SetConfiguration",
+
+			Request: func() *http.Request {
+				body, _ := json.Marshal(map[string]interface{}{
+					"key0": "value0",
+				})
+
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				app.On("SetConfiguration",
+					contextMatcher,
+					mock.AnythingOfType("uuid.UUID"),
+					model.Attributes{
+						{
+							Key:   "key0",
+							Value: "value0",
+						},
+					},
+				).Return(errors.New("some error"))
+				return app
+			}(),
+			Status: http.StatusInternalServerError,
+		},
+
+		{
+			Name: "error no auth",
+
+			Request: func() *http.Request {
+				body, _ := json.Marshal(map[string]interface{}{
+					"expected": []map[string]interface{}{
+						{
+							"key":   "key0",
+							"value": "value0",
+						},
+					},
+				})
+
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusUnauthorized,
+		},
+
+		{
+			Name: "error bad token format",
+
+			Request: func() *http.Request {
+				body, _ := json.Marshal(map[string]interface{}{
+					"expected": []map[string]interface{}{
+						{
+							"key":   "key0",
+							"value": "value0",
+						},
+					},
+				})
+
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusUnauthorized,
+		},
+
+		{
+			Name: "error url not found",
+
+			Request: func() *http.Request {
+				body, _ := json.Marshal(map[string]interface{}{
+					"expected": []map[string]interface{}{
+						{
+							"key":   "key0",
+							"value": "value0",
+						},
+					},
+				})
+
+				repl := strings.NewReplacer(
+					":device_id", "",
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusNotFound,
+		},
+
+		{
+			Name: "error bad request not a valid device id",
+
+			Request: func() *http.Request {
+				body, _ := json.Marshal(map[string]interface{}{
+					"expected": []map[string]interface{}{
+						{
+							"key":   "key0",
+							"value": "value0",
+						},
+					},
+				})
+
+				repl := strings.NewReplacer(
+					":device_id", "id",
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusBadRequest,
+		},
+
+		{
+			Name: "error bad request not a valid json in body",
+
+			Request: func() *http.Request {
+				body := []byte("not a valid json text")
+
+				repl := strings.NewReplacer(
+					":device_id", "id",
+				)
+				req, _ := http.NewRequest("PUT",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					bytes.NewReader(body),
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusBadRequest,
+		},
+	}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tc.App.AssertExpectations(t)
+			router := NewRouter(tc.App)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, tc.Request)
+			assert.Equal(t, tc.Status, w.Code)
+			if tc.Error != nil {
+				b, _ := json.Marshal(tc.Error)
+				assert.JSONEq(t, string(b), string(w.Body.Bytes()))
+			}
+		})
+	}
+}
+
+func TestGetConfiguration(t *testing.T) {
+	t.Parallel()
+
+	device := model.Device{
+		ID: uuid.New(),
+		DesiredAttributes: []model.Attribute{
+			{
+				Key:   "key0",
+				Value: "value0",
+			},
+			{
+				Key:   "key2",
+				Value: "value2",
+			},
+		},
+		CurrentAttributes: []model.Attribute{
+			{
+				Key:   "key1",
+				Value: "value1",
+			},
+			{
+				Key:   "key3",
+				Value: "value3",
+			},
+		},
+		UpdatedTS: time.Now(),
+		ReportTS:  time.Now(),
+	}
+
+	testCases := []struct {
+		Name string
+
+		TenantID string
+		Request  *http.Request
+
+		App    *mapp.App
+		Error  *rest.Error
+		Status int
+	}{
+		{
+			Name: "ok",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				app.On("GetDevice",
+					contextMatcher,
+					mock.AnythingOfType("uuid.UUID"),
+				).Return(device, nil)
+				return app
+			}(),
+			Status: http.StatusOK,
+		},
+
+		{
+			Name: "error no auth",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusUnauthorized,
+		},
+
+		{
+			Name: "error bad token format",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusUnauthorized,
+		},
+
+		{
+			Name: "error url not found",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", "",
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusNotFound,
+		},
+
+		{
+			Name: "error bad request not a valid device id",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", "id",
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				return app
+			}(),
+			Status: http.StatusBadRequest,
+		},
+
+		{
+			Name: "error device not found",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				app.On("GetDevice",
+					contextMatcher,
+					mock.AnythingOfType("uuid.UUID"),
+				).Return(device, store.ErrDeviceNoExist)
+				return app
+			}(),
+			Status: http.StatusNotFound,
+		},
+
+		{
+			Name: "error internal error on GetDevice",
+
+			Request: func() *http.Request {
+				repl := strings.NewReplacer(
+					":device_id", uuid.NewSHA1(
+						uuid.NameSpaceDNS, []byte("mender.io"),
+					).String(),
+				)
+				req, _ := http.NewRequest("GET",
+					"http://localhost"+URIManagement+repl.Replace(URIConfiguration),
+					nil,
+				)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibWVuZGVyLnBsYW4iOiJlbnRlcnByaXNlIn0.s27fi93Qik81WyBmDB5APE0DfGko7Pq8BImbp33-gy4")
+				return req
+			}(),
+
+			App: func() *mapp.App {
+				app := new(mapp.App)
+				app.On("GetDevice",
+					contextMatcher,
+					mock.AnythingOfType("uuid.UUID"),
+				).Return(device, errors.New("some other error"))
+				return app
+			}(),
+			Status: http.StatusInternalServerError,
+		},
+	}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tc.App.AssertExpectations(t)
+			router := NewRouter(tc.App)
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, tc.Request)
+			assert.Equal(t, tc.Status, w.Code)
+			if w.Code == http.StatusOK {
+				var d map[string]interface{}
+				json.Unmarshal(w.Body.Bytes(), &d)
+				t.Logf("got: %+v", d)
+				assert.Equal(t, d["configured"], attributes2Map(device.DesiredAttributes))
+			}
+			if tc.Error != nil {
+				b, _ := json.Marshal(tc.Error)
+				assert.JSONEq(t, string(b), string(w.Body.Bytes()))
+			}
+		})
+	}
+}
+
+func attributes2Map(attributes []model.Attribute) map[string]interface{} {
+	configurationMap := make(map[string]interface{}, len(attributes))
+	for _, a := range attributes {
+		switch a.Value.(type) {
+		case string:
+			configurationMap[a.Key] = a.Value.(string)
+		}
+	}
+
+	return configurationMap
+}

--- a/api/http/router.go
+++ b/api/http/router.go
@@ -38,6 +38,8 @@ const (
 	URITenantDevices = "/tenants/:tenant_id/devices"
 	URITenantDevice  = "/tenants/:tenant_id/devices/:device_id"
 
+	URIConfiguration = "/configurations/device/:device_id"
+
 	URIAlive  = "/alive"
 	URIHealth = "/health"
 )
@@ -69,10 +71,14 @@ func NewRouter(app app.App) http.Handler {
 	intrnlGrp.POST(URITenantDevices, intrnlAPI.ProvisionDevice)
 	intrnlGrp.DELETE(URITenantDevice, intrnlAPI.DecommissionDevice)
 
-	// mgmtAPI := NewManagementAPI(app)
+	mgmtAPI := NewManagementAPI(app)
 	mgmtGrp := router.Group(URIManagement)
+
 	// identity middleware for collecting JWT claims into request Context.
 	mgmtGrp.Use(identity.Middleware())
+	mgmtGrp.GET(URIConfiguration, mgmtAPI.GetConfiguration)
+	mgmtGrp.PUT(URIConfiguration, mgmtAPI.SetConfiguration)
+
 	// cors middleware for checking origin headers.
 	mgmtGrp.Use(cors.New(cors.Config{
 		AllowAllOrigins:  true,

--- a/app/app.go
+++ b/app/app.go
@@ -42,6 +42,9 @@ type App interface {
 
 	ProvisionDevice(ctx context.Context, dev model.NewDevice) error
 	DecommissionDevice(ctx context.Context, devID uuid.UUID) error
+
+	SetConfiguration(ctx context.Context, devID uuid.UUID, configuration model.Attributes) error
+	GetDevice(ctx context.Context, devID uuid.UUID) (model.Device, error)
 }
 
 // app is an app object
@@ -86,6 +89,21 @@ func (a *app) ProvisionDevice(ctx context.Context, dev model.NewDevice) error {
 		UpdatedTS: time.Now(),
 	})
 }
+
 func (a *app) DecommissionDevice(ctx context.Context, devID uuid.UUID) error {
 	return a.store.DeleteDevice(ctx, devID)
+}
+
+func (a *app) SetConfiguration(ctx context.Context,
+	devID uuid.UUID,
+	configuration model.Attributes) error {
+	return a.store.UpsertExpectedConfiguration(ctx, model.Device{
+		ID:                devID,
+		DesiredAttributes: configuration,
+		UpdatedTS:         time.Now(),
+	})
+}
+
+func (a *app) GetDevice(ctx context.Context, devID uuid.UUID) (model.Device, error) {
+	return a.store.GetDevice(ctx, devID)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -70,6 +70,36 @@ func TestProvisionDevice(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGetDevice(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+	dev := model.NewDevice{
+		ID: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")),
+	}
+	device := model.Device{
+		ID: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")),
+	}
+	deviceMatcher := mock.MatchedBy(func(d model.Device) bool {
+		if !assert.Equal(t, dev.ID, d.ID) {
+			return false
+		}
+		return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+	})
+
+	ds := new(mstore.DataStore)
+	defer ds.AssertExpectations(t)
+	ds.On("InsertDevice", ctx, deviceMatcher).Return(nil)
+	ds.On("GetDevice", ctx, dev.ID).Return(device, nil)
+
+	app := New(ds, Config{})
+	err := app.ProvisionDevice(ctx, dev)
+	assert.NoError(t, err)
+
+	d, err := app.GetDevice(ctx, dev.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, dev.ID, d.ID)
+}
+
 func TestDecommissionDevice(t *testing.T) {
 	t.Parallel()
 
@@ -83,4 +113,86 @@ func TestDecommissionDevice(t *testing.T) {
 	app := New(ds, Config{})
 	err := app.DecommissionDevice(ctx, devID)
 	assert.NoError(t, err)
+}
+
+func TestSetConfiguration(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+	dev := model.NewDevice{
+		ID: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")),
+	}
+	device := model.Device{
+		ID: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")),
+		DesiredAttributes: []model.Attribute{
+			{
+				Key:   "hostname",
+				Value: "some0",
+			},
+		},
+		CurrentAttributes: []model.Attribute{
+			{
+				Key:   "hostname",
+				Value: "some0other",
+			},
+		},
+	}
+	deviceMatcher := mock.MatchedBy(func(d model.Device) bool {
+		if !assert.Equal(t, dev.ID, d.ID) {
+			return false
+		}
+		return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+	})
+
+	ds := new(mstore.DataStore)
+	defer ds.AssertExpectations(t)
+	ds.On("InsertDevice", ctx, deviceMatcher).Return(nil)
+	ds.On("UpsertExpectedConfiguration", ctx, deviceMatcher).Return(nil)
+	ds.On("GetDevice", ctx, dev.ID).Return(device, nil)
+
+	app := New(ds, Config{})
+	err := app.ProvisionDevice(ctx, dev)
+	assert.NoError(t, err)
+
+	err = app.SetConfiguration(ctx, dev.ID, device.DesiredAttributes)
+	assert.NoError(t, err)
+
+	d, err := app.GetDevice(ctx, dev.ID)
+	assert.NoError(t, err)
+
+	assert.Equal(t, d.DesiredAttributes, device.DesiredAttributes)
+
+	err = app.SetConfiguration(ctx, dev.ID, []model.Attribute{
+		{
+			Key:   "hostname",
+			Value: "other",
+		},
+	})
+	assert.NoError(t, err)
+
+	d, err = app.GetDevice(ctx, dev.ID)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, device.DesiredAttributes, d.DesiredAttributes[0])
+
+	err = app.SetConfiguration(ctx, dev.ID, []model.Attribute{
+		{
+			Key:   "hostname",
+			Value: "",
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func map2Attributes(configurationMap map[string]interface{}) model.Attributes {
+	attributes := make(model.Attributes, len(configurationMap))
+	i := 0
+	for k, v := range configurationMap {
+		attributes[i] = model.Attribute{
+			Key:   k,
+			Value: v,
+		}
+		i++
+	}
+
+	return attributes
 }

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -44,6 +44,27 @@ func (_m *App) DecommissionDevice(ctx context.Context, devID uuid.UUID) error {
 	return r0
 }
 
+// GetDevice provides a mock function with given fields: ctx, devID
+func (_m *App) GetDevice(ctx context.Context, devID uuid.UUID) (model.Device, error) {
+	ret := _m.Called(ctx, devID)
+
+	var r0 model.Device
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) model.Device); ok {
+		r0 = rf(ctx, devID)
+	} else {
+		r0 = ret.Get(0).(model.Device)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
+		r1 = rf(ctx, devID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // HealthCheck provides a mock function with given fields: ctx
 func (_m *App) HealthCheck(ctx context.Context) error {
 	ret := _m.Called(ctx)
@@ -79,6 +100,20 @@ func (_m *App) ProvisionTenant(ctx context.Context, tenant model.NewTenant) erro
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, model.NewTenant) error); ok {
 		r0 = rf(ctx, tenant)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetConfiguration provides a mock function with given fields: ctx, devID, configuration
+func (_m *App) SetConfiguration(ctx context.Context, devID uuid.UUID, configuration model.Attributes) error {
+	ret := _m.Called(ctx, devID, configuration)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, model.Attributes) error); ok {
+		r0 = rf(ctx, devID, configuration)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -3,7 +3,7 @@ openapi: 3.0.3
 info:
   title: Device Configure Management API
   description: |
-    API for managing persistent device connections.
+    API for managing device configuration.
     Intended for use by the web GUI
 
   version: "1"
@@ -28,24 +28,51 @@ tags:
   - name: ManagementAPI
 
 paths:
-  /configuration:
+  /configurations/device/{deviceId}:
     get:
-      operationId: List Parameters
+      operationId: Get key-value pair store
       tags:
         - ManagementAPI
-      summary: Get existing parameters
-      # parameters: {}
+      summary: Query the configuration store; retrieve all key-value pairs
+      parameters:
+        - in: path
+          name: deviceId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: ID of the device to query.
       responses:
         200:
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Parameter'
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  configured:
+                    type: object
+                    $ref: '#/components/schemas/Configuration'
+                  reported:
+                    type: object
+                    $ref: '#/components/schemas/Configuration'
+                  reported_ts:
+                    type: string
+                    format: date-time
+                  updated_ts:
+                    type: string
+                    format: date-time
         400:
-          description: Invalid Request.
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Not Found.
           content:
             application/json:
               schema:
@@ -56,55 +83,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
     put:
-      operationId: Set Configuration
+      operationId: Store a set of key-value pairs
       tags:
         - ManagementAPI
-      summary: Assign configuration parameters
+      summary: Set a key-value pair store, updating if existing, removing if empty
       requestBody:
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: '#/components/schemas/Parameter'
-                - type: array
-                  items:
-                    $ref: '#/components/schemas/Parameter'
-      responses:
-        200:
-          description: Parameters set and updated successfully.
-        400:
-          description: Invalid Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        500:
-          description: Internal Server Error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-    delete:
-      operationId: Unset Configuration
-      tags:
-        - ManagementAPI
-      summary: Assign configuration parameters
+              $ref: '#/components/schemas/Configuration'
       parameters:
-        - name: 'key'
-          in: 'query'
+        - in: path
+          name: deviceId
           schema:
-            description: Name of the parameter(s) to delete.
-            type: "array"
-            items:
-              type: string
+            type: string
+          required: true
+          description: ID of the device to query.
       responses:
-        200:
-          description: Parameters set and updated successfully.
+        204:
+          description: Created
         400:
-          description: Invalid Request.
+          description: Bad Request.
           content:
             application/json:
               schema:
@@ -115,8 +115,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
-
 
 components:
   securitySchemes:
@@ -130,18 +128,10 @@ components:
         The JWT can be alternatively passed as a cookie named "JWT".
 
   schemas:
-    Parameter:
+    Configuration:
       type: object
-      properties:
-        key:
-          type: string
-          description: Configuration key name.
-        value:
-          anyOf:
-            - type: string
-            # - type: number
-            # - type: boolean
-            # - type: array
+      additionalProperties:
+        type: string
 
     Error:
       type: object
@@ -183,12 +173,11 @@ components:
 
     ForbiddenError:
       description: |
-          The user is not permitted to access the remote terminal
-          for a given device.
+          The user is not permitted to access the resource.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
           example:
-            error: "Access denied (RBAC)"
+            error: "Forbidden"
             request_id: "eed14d55-d996-42cd-8248-e806663810a8"

--- a/model/attribute_test.go
+++ b/model/attribute_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAttributes2Map(t *testing.T) {
+	configurationMap := map[string]interface{}{
+		"hostname": "some0",
+	}
+	attributes := []Attribute{
+		{
+			Key:   "hostname",
+			Value: "some0",
+		},
+	}
+	assert.Equal(t, attributes2Map(attributes), configurationMap)
+
+	configurationMap["hostname"] = "some0other"
+	assert.NotEqual(t, attributes2Map(attributes), configurationMap)
+}
+
+func TestMap2Attributes(t *testing.T) {
+	configurationMap := map[string]interface{}{
+		"hostname": "some0",
+	}
+	attributes := Attributes{
+		{
+			Key:   "hostname",
+			Value: "some0",
+		},
+	}
+	assert.Equal(t, map2Attributes(configurationMap), attributes)
+
+	configurationMap["hostname"] = "some0other"
+	assert.NotEqual(t, map2Attributes(configurationMap), attributes)
+}

--- a/model/device.go
+++ b/model/device.go
@@ -27,15 +27,15 @@ type Device struct {
 	ID uuid.UUID `bson:"_id" json:"id"`
 
 	// DesiredAttributes is the configured attributes for the device.
-	DesiredAttributes []Attribute `bson:"desired,omitempty" json:"desired"`
+	DesiredAttributes Attributes `bson:"configured,omitempty" json:"configured"`
 	// CurrentAttributes is the configuration reported by the device.
-	CurrentAttributes []Attribute `bson:"current,omitempty" json:"current"`
+	CurrentAttributes Attributes `bson:"reported,omitempty" json:"reported"`
 
 	// UpdatedTS holds the timestamp for when the desired state changed,
 	// including when the object was created.
 	UpdatedTS time.Time `bson:"updated_ts" json:"updated_ts"`
 	// ReportTS holds the timestamp when the device last reported its' state.
-	ReportTS time.Time `bson:"report_ts,omitempty" json:"report_ts,omitempty"`
+	ReportTS time.Time `bson:"reported_ts,omitempty" json:"reported_ts,omitempty"`
 }
 
 func (dev Device) Validate() error {

--- a/model/device_test.go
+++ b/model/device_test.go
@@ -57,7 +57,7 @@ func TestDeviceValidate(t *testing.T) {
 		},
 		Error: errors.New(
 			"invalid device object: " +
-				"current: (0: (value: invalid type: bool.); " +
+				"reported: (0: (value: invalid type: bool.); " +
 				"1: (value: invalid type: func().).).",
 		),
 	}, {

--- a/model/validation.go
+++ b/model/validation.go
@@ -24,9 +24,9 @@ var (
 	lengthLessThan4096 = validation.Length(0, 4096)
 
 	validateAttributeValue = validation.By(func(value interface{}) error {
-		switch t := value.(type) {
+		switch value.(type) {
 		case string:
-			return lengthLessThan4096.Validate(t)
+			return nil
 
 		default:
 			// NOTE: we will support more types in the future

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -47,6 +47,12 @@ type DataStore interface {
 	// InsertDeviceConfig inserts a new device configuration
 	InsertDevice(ctx context.Context, dev model.Device) error
 
+	// UpsertDeviceConfig updates or inserts a new device configuration
+	UpsertExpectedConfiguration(ctx context.Context, dev model.Device) error
+
 	// DeleteDevice removes the device object with the given ID from the database.
 	DeleteDevice(ctx context.Context, devID uuid.UUID) error
+
+	// GetDevice returns a device
+	GetDevice(ctx context.Context, devID uuid.UUID) (model.Device, error)
 }

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -72,6 +72,27 @@ func (_m *DataStore) DropDatabase(ctx context.Context) error {
 	return r0
 }
 
+// GetDevice provides a mock function with given fields: ctx, devID
+func (_m *DataStore) GetDevice(ctx context.Context, devID uuid.UUID) (model.Device, error) {
+	ret := _m.Called(ctx, devID)
+
+	var r0 model.Device
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) model.Device); ok {
+		r0 = rf(ctx, devID)
+	} else {
+		r0 = ret.Get(0).(model.Device)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
+		r1 = rf(ctx, devID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // InsertDevice provides a mock function with given fields: ctx, dev
 func (_m *DataStore) InsertDevice(ctx context.Context, dev model.Device) error {
 	ret := _m.Called(ctx, dev)
@@ -121,6 +142,20 @@ func (_m *DataStore) Ping(ctx context.Context) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpsertExpectedConfiguration provides a mock function with given fields: ctx, dev
+func (_m *DataStore) UpsertExpectedConfiguration(ctx context.Context, dev model.Device) error {
+	ret := _m.Called(ctx, dev)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.Device) error); ok {
+		r0 = rf(ctx, dev)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
MEN-4384 Management endpoints: set, get, remove key-value pairs.

    * PUT and GET are used to store and retrieve the whole "expected" conf set
    * to remove send empty array

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>