### PR TITLE
MEN-4598: make the deployment ID and the updated/reported ts optionals

### DIFF
--- a/api/http/devices_test.go
+++ b/api/http/devices_test.go
@@ -32,6 +32,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func ptrNow() *time.Time {
+	now := time.Now()
+	return &now
+}
+
 func TestDevicesSetConfiguration(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -252,8 +257,8 @@ func TestDevicesGetConfiguration(t *testing.T) {
 				Value: "value2",
 			},
 		},
-		UpdatedTS: time.Now(),
-		ReportTS:  time.Now(),
+		UpdatedTS: ptrNow(),
+		ReportTS:  ptrNow(),
 	}
 
 	testCases := []struct {

--- a/api/http/management_test.go
+++ b/api/http/management_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/mendersoftware/deviceconfig/store"
 	"github.com/stretchr/testify/mock"
@@ -403,8 +402,8 @@ func TestGetConfiguration(t *testing.T) {
 				Value: "value3",
 			},
 		},
-		UpdatedTS: time.Now(),
-		ReportTS:  time.Now(),
+		UpdatedTS: ptrNow(),
+		ReportTS:  ptrNow(),
 	}
 
 	testCases := []struct {
@@ -737,8 +736,8 @@ func TestDeployConfiguration(t *testing.T) {
 						Value: "value3",
 					},
 				},
-				UpdatedTS: time.Now(),
-				ReportTS:  time.Now(),
+				UpdatedTS: ptrNow(),
+				ReportTS:  ptrNow(),
 			},
 			requestBody: "{\"retries\": 0}",
 			deployConfiguration: model.DeployConfigurationResponse{
@@ -772,8 +771,8 @@ func TestDeployConfiguration(t *testing.T) {
 						Value: "value3",
 					},
 				},
-				UpdatedTS: time.Now(),
-				ReportTS:  time.Now(),
+				UpdatedTS: ptrNow(),
+				ReportTS:  ptrNow(),
 			},
 			requestBody:             "{\"retries\": 0}",
 			deployConfigurationErr:  errors.New("generic error"),
@@ -819,8 +818,8 @@ func TestDeployConfiguration(t *testing.T) {
 						Value: "value3",
 					},
 				},
-				UpdatedTS: time.Now(),
-				ReportTS:  time.Now(),
+				UpdatedTS: ptrNow(),
+				ReportTS:  ptrNow(),
 			},
 			callGetDevice: true,
 			status:        400,
@@ -849,8 +848,8 @@ func TestDeployConfiguration(t *testing.T) {
 						Value: "value3",
 					},
 				},
-				UpdatedTS: time.Now(),
-				ReportTS:  time.Now(),
+				UpdatedTS: ptrNow(),
+				ReportTS:  ptrNow(),
 			},
 			requestBody: "{\"retries\": 0}",
 			deployConfiguration: model.DeployConfigurationResponse{
@@ -886,8 +885,8 @@ func TestDeployConfiguration(t *testing.T) {
 						Value: "value3",
 					},
 				},
-				UpdatedTS: time.Now(),
-				ReportTS:  time.Now(),
+				UpdatedTS: ptrNow(),
+				ReportTS:  ptrNow(),
 			},
 			requestBody: "{\"retries\": 0}",
 			deployConfiguration: model.DeployConfigurationResponse{
@@ -921,8 +920,8 @@ func TestDeployConfiguration(t *testing.T) {
 						Value: "value3",
 					},
 				},
-				UpdatedTS: time.Now(),
-				ReportTS:  time.Now(),
+				UpdatedTS: ptrNow(),
+				ReportTS:  ptrNow(),
 			},
 			requestBody: "{\"retries\": 0}",
 			deployConfiguration: model.DeployConfigurationResponse{

--- a/app/app.go
+++ b/app/app.go
@@ -95,9 +95,10 @@ func (a *app) ProvisionTenant(ctx context.Context, tenant model.NewTenant) error
 }
 
 func (a *app) ProvisionDevice(ctx context.Context, dev model.NewDevice) error {
+	now := time.Now()
 	return a.store.InsertDevice(ctx, model.Device{
 		ID:        dev.ID,
-		UpdatedTS: time.Now(),
+		UpdatedTS: &now,
 	})
 }
 
@@ -108,10 +109,11 @@ func (a *app) DecommissionDevice(ctx context.Context, devID string) error {
 func (a *app) SetConfiguration(ctx context.Context,
 	devID string,
 	configuration model.Attributes) error {
+	now := time.Now()
 	err := a.store.UpsertConfiguration(ctx, model.Device{
 		ID:                   devID,
 		ConfiguredAttributes: configuration,
-		UpdatedTS:            time.Now(),
+		UpdatedTS:            &now,
 	})
 	if err != nil {
 		return err
@@ -148,10 +150,11 @@ func (a *app) SetConfiguration(ctx context.Context,
 func (a *app) SetReportedConfiguration(ctx context.Context,
 	devID string,
 	configuration model.Attributes) error {
+	now := time.Now()
 	return a.store.UpsertReportedConfiguration(ctx, model.Device{
 		ID:                 devID,
 		ReportedAttributes: configuration,
-		ReportTS:           time.Now(),
+		ReportTS:           &now,
 	})
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -87,7 +87,7 @@ func TestProvisionDevice(t *testing.T) {
 		if !assert.Equal(t, dev.ID, d.ID) {
 			return false
 		}
-		return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+		return assert.WithinDuration(t, time.Now(), *d.UpdatedTS, time.Minute)
 	})
 
 	ds := new(mstore.DataStore)
@@ -112,7 +112,7 @@ func TestGetDevice(t *testing.T) {
 		if !assert.Equal(t, dev.ID, d.ID) {
 			return false
 		}
-		return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+		return assert.WithinDuration(t, time.Now(), *d.UpdatedTS, time.Minute)
 	})
 
 	ds := new(mstore.DataStore)
@@ -169,7 +169,7 @@ func TestSetConfiguration(t *testing.T) {
 		if !assert.Equal(t, dev.ID, d.ID) {
 			return false
 		}
-		return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+		return assert.WithinDuration(t, time.Now(), *d.UpdatedTS, time.Minute)
 	})
 
 	ds := new(mstore.DataStore)
@@ -250,7 +250,7 @@ func TestSetConfigurationWithAuditLogs(t *testing.T) {
 				if !assert.Equal(t, dev.ID, d.ID) {
 					return false
 				}
-				return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+				return assert.WithinDuration(t, time.Now(), *d.UpdatedTS, time.Minute)
 			})
 
 			ds := new(mstore.DataStore)
@@ -321,13 +321,13 @@ func TestSetReportedConfiguration(t *testing.T) {
 		if !assert.Equal(t, dev.ID, d.ID) {
 			return false
 		}
-		return assert.WithinDuration(t, time.Now(), d.UpdatedTS, time.Minute)
+		return assert.WithinDuration(t, time.Now(), *d.UpdatedTS, time.Minute)
 	})
 	deviceMatcherReport := mock.MatchedBy(func(d model.Device) bool {
 		if !assert.Equal(t, dev.ID, d.ID) {
 			return false
 		}
-		return assert.WithinDuration(t, time.Now(), d.ReportTS, time.Minute)
+		return assert.WithinDuration(t, time.Now(), *d.ReportTS, time.Minute)
 	})
 
 	ds := new(mstore.DataStore)

--- a/model/device.go
+++ b/model/device.go
@@ -31,13 +31,13 @@ type Device struct {
 	// ReportedAttributes are the configuration reported by the device.
 	ReportedAttributes Attributes `bson:"reported,omitempty" json:"reported"`
 	// DeploymentID is the ID of the latest configuration deployment
-	DeploymentID uuid.UUID `bson:"deployment_id,omitempty" json:"deployment_id,omitempty"`
+	DeploymentID *uuid.UUID `bson:"deployment_id,omitempty" json:"deployment_id,omitempty"`
 
 	// UpdatedTS holds the timestamp for when the desired state changed,
 	// including when the object was created.
-	UpdatedTS time.Time `bson:"updated_ts" json:"updated_ts"`
+	UpdatedTS *time.Time `bson:"updated_ts" json:"updated_ts"`
 	// ReportTS holds the timestamp when the device last reported its' state.
-	ReportTS time.Time `bson:"reported_ts,omitempty" json:"reported_ts,omitempty"`
+	ReportTS *time.Time `bson:"reported_ts,omitempty" json:"reported_ts,omitempty"`
 }
 
 func (dev Device) Validate() error {

--- a/model/device_test.go
+++ b/model/device_test.go
@@ -35,6 +35,8 @@ func TestDeviceValidate(t *testing.T) {
 		})
 	}
 
+	now := time.Now()
+
 	testCases := []struct {
 		Name string
 
@@ -49,7 +51,7 @@ func TestDeviceValidate(t *testing.T) {
 				Key:   "HOME",
 				Value: "/root",
 			}},
-			UpdatedTS: time.Now(),
+			UpdatedTS: &now,
 		},
 	}, {
 		Name: "error, bad type",
@@ -63,7 +65,7 @@ func TestDeviceValidate(t *testing.T) {
 				Key:   "illegal#2",
 				Value: func() { return },
 			}},
-			UpdatedTS: time.Now(),
+			UpdatedTS: &now,
 		},
 		Error: errors.New(
 			"invalid device object: " +

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -30,6 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ptrNow() *time.Time {
+	now := time.Now()
+	return &now
+}
+
 func TestPing(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -171,13 +176,13 @@ func TestInsertDevice(t *testing.T) {
 
 		Devices: []model.Device{{
 			ID:        uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")).String(),
-			UpdatedTS: time.Now(),
+			UpdatedTS: ptrNow(),
 		}},
 	}, {
 		Name: "error, invalid document",
 
 		Devices: []model.Device{{
-			UpdatedTS: time.Now(),
+			UpdatedTS: ptrNow(),
 		}},
 		Error: errors.New(`^invalid device object: id: cannot be blank.$`),
 	}, {
@@ -190,21 +195,21 @@ func TestInsertDevice(t *testing.T) {
 
 		Devices: []model.Device{{
 			ID:        uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")).String(),
-			UpdatedTS: time.Now(),
+			UpdatedTS: ptrNow(),
 		}},
 		Error: errors.New(
 			`mongo: failed to store device configuration: .*` +
-				context.Canceled.Error() + `$`,
+				context.Canceled.Error(),
 		),
 	}, {
 		Name: "error, duplicate key",
 
 		Devices: []model.Device{{
 			ID:        uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")).String(),
-			UpdatedTS: time.Now(),
+			UpdatedTS: ptrNow(),
 		}, {
 			ID:        uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")).String(),
-			UpdatedTS: time.Now(),
+			UpdatedTS: ptrNow(),
 		}},
 		Error: store.ErrDeviceAlreadyExists,
 	}}
@@ -269,7 +274,7 @@ func TestGetDevice(t *testing.T) {
 							Value: "value2",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 			FoundDevices: []model.Device{
@@ -287,7 +292,7 @@ func TestGetDevice(t *testing.T) {
 							Value: "value2",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 		},
@@ -310,7 +315,7 @@ func TestGetDevice(t *testing.T) {
 							Value: "value2",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 			FoundDevices: []model.Device{
@@ -327,7 +332,7 @@ func TestGetDevice(t *testing.T) {
 							Value: "value2",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 			Error: errors.New("mongo: device does not exist"),
@@ -361,8 +366,9 @@ func TestGetDevice(t *testing.T) {
 				}
 				d, err := ds.GetDevice(tc.CTX, dev.ID)
 				assert.NoError(t, err)
-				d.UpdatedTS = time.Unix(1, 0)
-				dev.UpdatedTS = time.Unix(1, 0)
+				timeVal := time.Unix(1, 0)
+				d.UpdatedTS = &timeVal
+				dev.UpdatedTS = &timeVal
 				assert.Equal(t, d, dev)
 			}
 		})
@@ -387,7 +393,7 @@ func TestUpsertConfiguration(t *testing.T) {
 			Devices: []model.Device{
 				{
 					ID:        deviceID,
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 
@@ -400,7 +406,7 @@ func TestUpsertConfiguration(t *testing.T) {
 							Value: "value0",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 		},
@@ -417,7 +423,7 @@ func TestUpsertConfiguration(t *testing.T) {
 							Value: "value0",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 
@@ -425,7 +431,7 @@ func TestUpsertConfiguration(t *testing.T) {
 				{
 					ID:                   deviceID,
 					ConfiguredAttributes: model.Attributes{},
-					UpdatedTS:            time.Now(),
+					UpdatedTS:            ptrNow(),
 				},
 			},
 		},
@@ -441,7 +447,7 @@ func TestUpsertConfiguration(t *testing.T) {
 							Value: "value0",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 
@@ -449,7 +455,7 @@ func TestUpsertConfiguration(t *testing.T) {
 				{
 					ID:                   deviceID,
 					ConfiguredAttributes: model.Attributes{},
-					UpdatedTS:            time.Now(),
+					UpdatedTS:            ptrNow(),
 				},
 			},
 
@@ -525,7 +531,7 @@ func TestUpsertReportedConfiguration(t *testing.T) {
 			Devices: []model.Device{
 				{
 					ID:        deviceID,
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 
@@ -538,7 +544,7 @@ func TestUpsertReportedConfiguration(t *testing.T) {
 							Value: "value0",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 		},
@@ -554,7 +560,7 @@ func TestUpsertReportedConfiguration(t *testing.T) {
 							Value: "value0",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 
@@ -562,7 +568,7 @@ func TestUpsertReportedConfiguration(t *testing.T) {
 				{
 					ID:                 deviceID,
 					ReportedAttributes: model.Attributes{},
-					UpdatedTS:          time.Now(),
+					UpdatedTS:          ptrNow(),
 				},
 			},
 		},
@@ -577,7 +583,7 @@ func TestUpsertReportedConfiguration(t *testing.T) {
 							Value: "value0",
 						},
 					},
-					UpdatedTS: time.Now(),
+					UpdatedTS: ptrNow(),
 				},
 			},
 
@@ -585,7 +591,7 @@ func TestUpsertReportedConfiguration(t *testing.T) {
 				{
 					ID:                 deviceID,
 					ReportedAttributes: model.Attributes{},
-					UpdatedTS:          time.Now(),
+					UpdatedTS:          ptrNow(),
 				},
 			},
 
@@ -648,7 +654,7 @@ func TestSetDeploymentID(t *testing.T) {
 
 	var testDevice = model.Device{
 		ID:        uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")).String(),
-		UpdatedTS: time.Now(),
+		UpdatedTS: ptrNow(),
 	}
 
 	testCases := []struct {
@@ -730,7 +736,7 @@ func TestDeleteDevice(t *testing.T) {
 
 	var testDevice = model.Device{
 		ID:        uuid.NewSHA1(uuid.NameSpaceDNS, []byte("mender.io")).String(),
-		UpdatedTS: time.Now(),
+		UpdatedTS: ptrNow(),
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
If the device reports the configuration before the backend sets it,
these fields are populated with a zero value. Convert them to pointers
to avoid storing the zero values in the database.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit dbf23d2be9896b8a531d3a98843825f7b538f7f8)