### PR TITLE
Increase golangci timeout to 5 minutes to avoid spurious failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
 
   # Skip linting _test.go files
   tests: false


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>