### PR TITLE
Added absent config variables from config.go

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,16 @@ mongo_username: ""
 # Overwrite with environment variable: DEVICECONFIG_MONGO_PASSWORD
 mongo_password: ""
 
+# Inventory service URI
+# Defaults to: "http://mender-inventory:8080"
+# Overwrite with environment variable: DEVICECONFIG_INVENTORY_URI
+DEVICECONFIG_INVENTORY_URI: http://mender-inventory:8080
+
+# Inventory timeout
+# Defaults to: 10
+# Overwrite with environment variable: DEVICECONFIG_INVENTORY_TIMEOUT
+DEVICECONFIG_INVENTORY_TIMEOUT: 10
+
 ## workflows service URL
 ## Defaults to: "http://mender-workflows-server:8080"
 ## Overwrite with environment variable DEVICECONFIG_WORKFLOWS_URL


### PR DESCRIPTION
The config.yaml didn't have all variables defined in config.go.
Added DEVICECONFIG_INVENTORY_URI and DEVICECONFIG_INVENTORY_TIMEOUT to the config.yaml.

@tranchitella 