### PR TITLE
QA-235: pipeline: Switch to static checks by golangci-lint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-golang-static.yml'
+    file: '.gitlab-ci-check-golang-lint.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-unittests.yml'
   - project: 'Northern.tech/Mender/mendertesting'
@@ -27,16 +27,6 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
-
-test:static:
-  image: golang:1.15
-  needs: []
-  before_script:
-    - |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-           sh -s -- -b $(go env GOPATH)/bin v1.31.0
-  script:
-    - golangci-lint run -v
 
 test:unit:
   image: golang:1.15

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - errcheck
     - gocyclo
     - gofmt
+    - goimports
     - gosimple
     - govet
     - ineffassign
@@ -32,10 +33,16 @@ linters:
 
 linters-settings:
   gocyclo:
-    min-complexity: 20 # default is 30.
+    # default is 30.
+    min-complexity: 20
+
+  goimports:
+    # to be edited by the template
+    local-prefixes:
+      "github.com/mendersoftware/deviceconfig"
 
   lll:
     # max line length, lines longer will be reported. Default is 120.
     line-length: 100
     # tab width in spaces. Default to 1.
-    tab-width: 8
+    tab-width: 4

--- a/api/http/router.go
+++ b/api/http/router.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/mendersoftware/deviceconfig/app"
 	"github.com/mendersoftware/go-lib-micro/accesslog"
 	"github.com/mendersoftware/go-lib-micro/identity"
 	"github.com/mendersoftware/go-lib-micro/requestid"
+
+	"github.com/mendersoftware/deviceconfig/app"
 )
 
 // API URL used by the HTTP router

--- a/model/attribute.go
+++ b/model/attribute.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"encoding/json"
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
+
 	"github.com/mendersoftware/deviceconfig/model"
 )
 


### PR DESCRIPTION
Modify the existing .golangci.yml to follow standard and fix goimports
linting issues.