### PR TITLE
[MEN-5153] New internal PATCH /configuration API

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,15 +28,6 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
 
-test:unit:
-  image: golang:1.15
-  needs: []
-  services:
-    - name: mongo:4.4
-      alias: mender-mongo
-  variables:
-    DEVICECONFIG_MONGO_URL: "mongodb://mender-mongo"
-
 test:acceptance:
   stage: test
   needs: []

--- a/api/http/router.go
+++ b/api/http/router.go
@@ -34,6 +34,7 @@ const (
 	URIManagement = "/api/management/v1/deviceconfig"
 
 	URITenants       = "/tenants"
+	URITenant        = "/tenants/:tenant_id"
 	URITenantDevices = "/tenants/:tenant_id/devices"
 	URITenantDevice  = "/tenants/:tenant_id/devices/:device_id"
 
@@ -71,6 +72,8 @@ func NewRouter(app app.App) http.Handler {
 	intrnlGrp.POST(URITenants, intrnlAPI.ProvisionTenant)
 	intrnlGrp.POST(URITenantDevices, intrnlAPI.ProvisionDevice)
 	intrnlGrp.DELETE(URITenantDevice, intrnlAPI.DecommissionDevice)
+
+	intrnlGrp.PATCH(URITenant+URIConfiguration, intrnlAPI.UpdateConfiguration)
 
 	mgmtAPI := NewManagementAPI(app)
 	mgmtGrp := router.Group(URIManagement)

--- a/app/app.go
+++ b/app/app.go
@@ -110,7 +110,7 @@ func (a *app) SetConfiguration(ctx context.Context,
 	devID string,
 	configuration model.Attributes) error {
 	now := time.Now()
-	err := a.store.UpsertConfiguration(ctx, model.Device{
+	err := a.store.ReplaceConfiguration(ctx, model.Device{
 		ID:                   devID,
 		ConfiguredAttributes: configuration,
 		UpdatedTS:            &now,
@@ -151,7 +151,7 @@ func (a *app) SetReportedConfiguration(ctx context.Context,
 	devID string,
 	configuration model.Attributes) error {
 	now := time.Now()
-	return a.store.UpsertReportedConfiguration(ctx, model.Device{
+	return a.store.ReplaceReportedConfiguration(ctx, model.Device{
 		ID:                 devID,
 		ReportedAttributes: configuration,
 		ReportTS:           &now,

--- a/app/app.go
+++ b/app/app.go
@@ -47,6 +47,7 @@ type App interface {
 	DecommissionDevice(ctx context.Context, devID string) error
 
 	SetConfiguration(ctx context.Context, devID string, configuration model.Attributes) error
+	UpdateConfiguration(ctx context.Context, devID string, attrs model.Attributes) error
 	SetReportedConfiguration(ctx context.Context, devID string, configuration model.Attributes) error
 	GetDevice(ctx context.Context, devID string) (model.Device, error)
 	DeployConfiguration(ctx context.Context, device model.Device, request model.DeployConfigurationRequest) (model.DeployConfigurationResponse, error)
@@ -144,6 +145,43 @@ func (a *app) SetConfiguration(ctx context.Context,
 		}
 	}
 
+	return nil
+}
+
+func (a *app) UpdateConfiguration(
+	ctx context.Context,
+	devID string,
+	attrs model.Attributes,
+) error {
+	err := a.store.UpdateConfiguration(ctx, devID, attrs)
+	if err != nil {
+		return err
+	}
+	if identity := identity.FromContext(ctx); identity != nil &&
+		identity.IsUser && a.HaveAuditLogs {
+		userID := identity.Subject
+		configuration, err := attrs.MarshalJSON()
+		if err == nil {
+			err = a.workflows.SubmitAuditLog(ctx, workflows.AuditLog{
+				Action: workflows.ActionSetConfiguration,
+				Actor: workflows.Actor{
+					ID:   userID,
+					Type: workflows.ActorUser,
+				},
+				Object: workflows.Object{
+					ID:   devID,
+					Type: workflows.ObjectDevice,
+				},
+				Change:  string(configuration),
+				EventTS: time.Now(),
+			})
+		}
+		if err != nil {
+			return errors.Wrap(err,
+				"failed to submit audit log for setting the device configuration",
+			)
+		}
+	}
 	return nil
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -178,7 +178,7 @@ func (a *app) UpdateConfiguration(
 		}
 		if err != nil {
 			return errors.Wrap(err,
-				"failed to submit audit log for setting the device configuration",
+				"failed to submit audit log for updating the device configuration",
 			)
 		}
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/mendersoftware/go-lib-micro/identity"
 )
 
+var contextMatcher = mock.MatchedBy(func(ctx context.Context) bool { return true })
+
 func TestHealthCheck(t *testing.T) {
 	t.Parallel()
 	err := errors.New("error")
@@ -210,6 +212,168 @@ func TestSetConfiguration(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
+}
+
+func TestUpdateConfiguration(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		Name string
+
+		CTX      context.Context
+		DeviceID string
+		Attrs    model.Attributes
+
+		Store func(t *testing.T, self *testCase) *mstore.DataStore
+		Wf    func(t *testing.T, self *testCase) *mworkflows.Client
+
+		Error error
+	}
+	testCases := []testCase{{
+		Name: "ok/single tenant",
+
+		CTX:      context.Background(),
+		DeviceID: "e1ce5c7a-5819-4ee1-aff7-f4fb0b50009c",
+		Attrs: model.Attributes{{
+			Key:   "key",
+			Value: "value",
+		}},
+
+		Store: func(t *testing.T, self *testCase) *mstore.DataStore {
+			store := new(mstore.DataStore)
+			store.On("UpdateConfiguration",
+				contextMatcher,
+				self.DeviceID,
+				self.Attrs,
+			).Return(nil).Once()
+			return store
+		},
+		Wf: func(t *testing.T, self *testCase) *mworkflows.Client {
+			return new(mworkflows.Client)
+		},
+	}, {
+		Name: "ok/with audit",
+
+		CTX: identity.WithContext(context.Background(), &identity.Identity{
+			Subject: "f363a096-3ef6-4871-be81-f39ca751d0c0",
+			IsUser:  true,
+		}),
+		DeviceID: "e1ce5c7a-5819-4ee1-aff7-f4fb0b50009c",
+		Attrs: model.Attributes{{
+			Key:   "key",
+			Value: "value",
+		}},
+
+		Store: func(t *testing.T, self *testCase) *mstore.DataStore {
+			store := new(mstore.DataStore)
+			store.On("UpdateConfiguration",
+				contextMatcher,
+				self.DeviceID,
+				self.Attrs,
+			).Return(nil).Once()
+			return store
+		},
+		Wf: func(t *testing.T, self *testCase) *mworkflows.Client {
+			wf := new(mworkflows.Client)
+			id := identity.FromContext(self.CTX)
+			wf.On("SubmitAuditLog",
+				self.CTX,
+				mock.AnythingOfType("workflows.AuditLog")).
+				Run(func(args mock.Arguments) {
+					al, ok := args.Get(1).(workflows.AuditLog)
+					if assert.True(t, ok) {
+						assert.Equal(t, id.Subject, al.Actor.ID)
+						assert.Equal(t, self.DeviceID, al.Object.ID)
+						assert.WithinDuration(t, time.Now(), al.EventTS, 5*time.Minute)
+					}
+				}).Return(nil).Once()
+			return wf
+		},
+	}, {
+		Name: "error/submitting audit",
+
+		CTX: identity.WithContext(context.Background(), &identity.Identity{
+			Subject: "f363a096-3ef6-4871-be81-f39ca751d0c0",
+			IsUser:  true,
+		}),
+		DeviceID: "e1ce5c7a-5819-4ee1-aff7-f4fb0b50009c",
+		Attrs: model.Attributes{{
+			Key:   "key",
+			Value: "value",
+		}},
+
+		Store: func(t *testing.T, self *testCase) *mstore.DataStore {
+			store := new(mstore.DataStore)
+			store.On("UpdateConfiguration",
+				contextMatcher,
+				self.DeviceID,
+				self.Attrs,
+			).Return(nil).Once()
+			return store
+		},
+		Wf: func(t *testing.T, self *testCase) *mworkflows.Client {
+			wf := new(mworkflows.Client)
+			id := identity.FromContext(self.CTX)
+			wf.On("SubmitAuditLog",
+				self.CTX,
+				mock.AnythingOfType("workflows.AuditLog")).
+				Run(func(args mock.Arguments) {
+					al, ok := args.Get(1).(workflows.AuditLog)
+					if assert.True(t, ok) {
+						assert.Equal(t, id.Subject, al.Actor.ID)
+						assert.Equal(t, self.DeviceID, al.Object.ID)
+						assert.WithinDuration(t, time.Now(), al.EventTS, 5*time.Minute)
+					}
+				}).Return(errors.New("internal error")).Once()
+			return wf
+		},
+
+		Error: errors.New("failed to submit audit log for updating " +
+			"the device configuration: internal error"),
+	}, {
+		Name: "error/internal",
+
+		CTX:      context.Background(),
+		DeviceID: "e1ce5c7a-5819-4ee1-aff7-f4fb0b50009c",
+		Attrs: model.Attributes{{
+			Key:   "key",
+			Value: "value",
+		}},
+
+		Store: func(t *testing.T, self *testCase) *mstore.DataStore {
+			store := new(mstore.DataStore)
+			store.On("UpdateConfiguration",
+				contextMatcher,
+				self.DeviceID,
+				self.Attrs,
+			).Return(errors.New("internal error")).Once()
+			return store
+		},
+		Wf: func(t *testing.T, self *testCase) *mworkflows.Client {
+			return new(mworkflows.Client)
+		},
+
+		Error: errors.New("internal error"),
+	}}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ds := tc.Store(t, &tc)
+			wf := tc.Wf(t, &tc)
+			defer ds.AssertExpectations(t)
+			defer wf.AssertExpectations(t)
+
+			app := New(ds, nil, wf, Config{HaveAuditLogs: true})
+			err := app.UpdateConfiguration(tc.CTX, tc.DeviceID, tc.Attrs)
+			if tc.Error != nil {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.Error.Error(), err.Error())
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestSetConfigurationWithAuditLogs(t *testing.T) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -175,7 +175,7 @@ func TestSetConfiguration(t *testing.T) {
 	ds := new(mstore.DataStore)
 	defer ds.AssertExpectations(t)
 	ds.On("InsertDevice", ctx, deviceMatcher).Return(nil)
-	ds.On("UpsertConfiguration", ctx, deviceMatcher).Return(nil)
+	ds.On("ReplaceConfiguration", ctx, deviceMatcher).Return(nil)
 	ds.On("GetDevice", ctx, dev.ID).Return(device, nil)
 
 	app := New(ds, nil, nil, Config{})
@@ -256,7 +256,7 @@ func TestSetConfigurationWithAuditLogs(t *testing.T) {
 			ds := new(mstore.DataStore)
 			defer ds.AssertExpectations(t)
 			ds.On("InsertDevice", ctx, deviceMatcher).Return(nil)
-			ds.On("UpsertConfiguration", ctx, deviceMatcher).Return(nil)
+			ds.On("ReplaceConfiguration", ctx, deviceMatcher).Return(nil)
 
 			wflows := &mworkflows.Client{}
 			defer wflows.AssertExpectations(t)
@@ -333,7 +333,7 @@ func TestSetReportedConfiguration(t *testing.T) {
 	ds := new(mstore.DataStore)
 	defer ds.AssertExpectations(t)
 	ds.On("InsertDevice", ctx, deviceMatcher).Return(nil)
-	ds.On("UpsertReportedConfiguration", ctx, deviceMatcherReport).Return(nil)
+	ds.On("ReplaceReportedConfiguration", ctx, deviceMatcherReport).Return(nil)
 	ds.On("GetDevice", ctx, dev.ID).Return(device, nil)
 
 	app := New(ds, nil, nil, Config{})

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -174,3 +174,17 @@ func (_m *App) SetReportedConfiguration(ctx context.Context, devID string, confi
 
 	return r0
 }
+
+// UpdateConfiguration provides a mock function with given fields: ctx, devID, attrs
+func (_m *App) UpdateConfiguration(ctx context.Context, devID string, attrs model.Attributes) error {
+	ret := _m.Called(ctx, devID, attrs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.Attributes) error); ok {
+		r0 = rf(ctx, devID, attrs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/model/attribute.go
+++ b/model/attribute.go
@@ -40,6 +40,10 @@ func (attr Attribute) Validate() error {
 
 type Attributes []Attribute
 
+func (a Attributes) Validate() error {
+	return validation.Validate([]Attribute(a), validateAttributesLength)
+}
+
 func map2Attributes(configurationMap map[string]interface{}) Attributes {
 	attributes := make(Attributes, len(configurationMap))
 	i := 0

--- a/model/device.go
+++ b/model/device.go
@@ -43,8 +43,8 @@ type Device struct {
 func (dev Device) Validate() error {
 	err := validation.ValidateStruct(&dev,
 		validation.Field(&dev.ID, validation.Required),
-		validation.Field(&dev.ConfiguredAttributes, validateAttributes),
-		validation.Field(&dev.ReportedAttributes, validateAttributes),
+		validation.Field(&dev.ConfiguredAttributes),
+		validation.Field(&dev.ReportedAttributes),
 	)
 	return errors.Wrap(err, "invalid device object")
 }

--- a/model/device_test.go
+++ b/model/device_test.go
@@ -28,7 +28,7 @@ func TestDeviceValidate(t *testing.T) {
 	t.Parallel()
 
 	tooManyAttributes := []Attribute{}
-	for i := 1; i <= maxNumberOfAttributes+1; i++ {
+	for i := 1; i <= AttributesMaxLength+1; i++ {
 		tooManyAttributes = append(tooManyAttributes, Attribute{
 			Key:   fmt.Sprintf("key%d", i),
 			Value: "value",
@@ -88,7 +88,7 @@ func TestDeviceValidate(t *testing.T) {
 			ConfiguredAttributes: tooManyAttributes,
 		},
 		Error: errors.New(
-			fmt.Sprintf("invalid device object: configured: too many configuration attributes, maximum is %d.", maxNumberOfAttributes),
+			fmt.Sprintf("invalid device object: configured: too many configuration attributes, maximum is %d.", AttributesMaxLength),
 		),
 	}}
 	for i := range testCases {

--- a/model/validation.go
+++ b/model/validation.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const maxNumberOfAttributes = 100
+const AttributesMaxLength = 100
 
 var (
 	lengthLessThan4096 = validation.Length(0, 4096)
@@ -37,15 +37,10 @@ var (
 		}
 	})
 
-	validateAttributes = validation.By(func(value interface{}) error {
-		attributes, ok := value.(Attributes)
-		if !ok {
-			return errors.Errorf("value is not an Attributes type: %T", value)
-		} else if len(attributes) > maxNumberOfAttributes {
-			msg := fmt.Sprintf("too many configuration attributes, maximum is %d",
-				maxNumberOfAttributes)
-			return errors.New(msg)
-		}
-		return nil
-	})
+	validateAttributesLength = validation.Length(
+		0, AttributesMaxLength,
+	).Error(fmt.Sprintf(
+		"too many configuration attributes, maximum is %d",
+		AttributesMaxLength,
+	))
 )

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -48,11 +48,15 @@ type DataStore interface {
 	// InsertDeviceConfig inserts a new device configuration
 	InsertDevice(ctx context.Context, dev model.Device) error
 
-	// UpsertDeviceConfig updates or inserts a new device configuration
-	UpsertConfiguration(ctx context.Context, dev model.Device) error
+	// ReplaceConfiguration replaces or inserts a new device configuration
+	ReplaceConfiguration(ctx context.Context, dev model.Device) error
 
-	// UpsertReportedConfiguration updates or inserts a new device reported configuration
-	UpsertReportedConfiguration(ctx context.Context, dev model.Device) error
+	// ReplaceReportedConfiguration replaces or inserts a new device reported configuration
+	ReplaceReportedConfiguration(ctx context.Context, dev model.Device) error
+
+	// UpdateConfiguration updates the attributes for deviceID by adding the new attributes
+	// to the existing set of (desired) attributes).
+	UpdateConfiguration(ctx context.Context, deviceID string, attrs model.Attributes) error
 
 	// SetDeploymentID updates the deployment ID of the device
 	SetDeploymentID(ctx context.Context, devID string, deploymentID uuid.UUID) error

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -149,6 +149,34 @@ func (_m *DataStore) Ping(ctx context.Context) error {
 	return r0
 }
 
+// ReplaceConfiguration provides a mock function with given fields: ctx, dev
+func (_m *DataStore) ReplaceConfiguration(ctx context.Context, dev model.Device) error {
+	ret := _m.Called(ctx, dev)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.Device) error); ok {
+		r0 = rf(ctx, dev)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ReplaceReportedConfiguration provides a mock function with given fields: ctx, dev
+func (_m *DataStore) ReplaceReportedConfiguration(ctx context.Context, dev model.Device) error {
+	ret := _m.Called(ctx, dev)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.Device) error); ok {
+		r0 = rf(ctx, dev)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetDeploymentID provides a mock function with given fields: ctx, devID, deploymentID
 func (_m *DataStore) SetDeploymentID(ctx context.Context, devID string, deploymentID uuid.UUID) error {
 	ret := _m.Called(ctx, devID, deploymentID)
@@ -163,27 +191,13 @@ func (_m *DataStore) SetDeploymentID(ctx context.Context, devID string, deployme
 	return r0
 }
 
-// UpsertConfiguration provides a mock function with given fields: ctx, dev
-func (_m *DataStore) UpsertConfiguration(ctx context.Context, dev model.Device) error {
-	ret := _m.Called(ctx, dev)
+// UpdateConfiguration provides a mock function with given fields: ctx, deviceID, attrs
+func (_m *DataStore) UpdateConfiguration(ctx context.Context, deviceID string, attrs model.Attributes) error {
+	ret := _m.Called(ctx, deviceID, attrs)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.Device) error); ok {
-		r0 = rf(ctx, dev)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpsertReportedConfiguration provides a mock function with given fields: ctx, dev
-func (_m *DataStore) UpsertReportedConfiguration(ctx context.Context, dev model.Device) error {
-	ret := _m.Called(ctx, dev)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.Device) error); ok {
-		r0 = rf(ctx, dev)
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.Attributes) error); ok {
+		r0 = rf(ctx, deviceID, attrs)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
This endpoint is required for populating the Azure connection string to deviceconfig service (see mendersoftware/azure-iot-manager#9).