### PR TITLE
chore(QA-148): CLI coverage for acceptance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,17 +35,21 @@ test:acceptance:
     - /^saas-[a-zA-Z0-9.-]+$/
   tags:
     - docker
-  image: docker:19.03.13
+  image: docker:20.10.12
   services:
-    - name: docker:19.03.13-dind
+    - name: docker:20.10.12-dind
       alias: docker
   before_script:
     - apk add docker-compose make
   script:
     - make acceptance-tests
   after_script:
-    - make acceptance-tests-logs
-    - make acceptance-tests-down
+    - set -- tests/coverage-acceptance@*.txt
+    - head -n 1 $1 > tests/coverage-acceptance.txt
+    - |
+      for cover in $@; do
+        tail -n +2 $cover >> tests/coverage-acceptance.txt;
+      done
   artifacts:
     expire_in: 2w
     paths:
@@ -57,7 +61,7 @@ publish:acceptance:
   stage: publish
   except:
     - /^saas-[a-zA-Z0-9.-]+$/
-  image: golang:1.15
+  image: golang:1.17
   needs:
     - job: test:acceptance
       artifacts: true
@@ -71,7 +75,6 @@ publish:acceptance:
     #  and pass few others as command line arguments.
     #  See also https://docs.coveralls.io/api-reference
     - export CI_BRANCH=${CI_COMMIT_BRANCH}
-    - export CI_PR_NUMBER=${CI_COMMIT_BRANCH#pr_}
   script:
     - goveralls
       -repotoken ${COVERALLS_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-alpine3.12 as builder
+FROM golang:1.17.6-alpine3.15 as builder
 RUN apk add --no-cache \
     xz-dev \
     musl-dev \

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-alpine3.12 as builder
+FROM golang:1.17.6-alpine3.15 as builder
 RUN apk add --no-cache \
     xz-dev \
     musl-dev \
@@ -13,11 +13,10 @@ FROM alpine:3.15.0
 RUN apk add --no-cache ca-certificates xz
 RUN mkdir -p /etc/deviceconfig
 COPY ./config.yaml /etc/deviceconfig
-COPY --from=builder /go/src/github.com/mendersoftware/deviceconfig/bin/deviceconfig.test /usr/bin
-ENTRYPOINT ["/usr/bin/deviceconfig.test", \
-        "-test.coverprofile=/testing/coverage-acceptance.txt", \
-        "-acceptance-testing", \
-        "--", "--config=/etc/deviceconfig/config.yaml", \
+COPY --from=builder /go/src/github.com/mendersoftware/deviceconfig/bin/deviceconfig.test \
+    /usr/bin/deviceconfig
+ENTRYPOINT ["/usr/bin/deviceconfig", \
+        "--config=/etc/deviceconfig/config.yaml", \
         "server", "--automigrate"]
 
 EXPOSE 8080

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Northern.tech AS
+Copyright 2022 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,6 @@
 #
 # Apache-2.0
-b4acfcfa2a0ba1a8c82ec3965fbcee886cff8394ca4214e0ddac0a36beb1e05a  LICENSE
+1033348db7606a7e61b6484f293847cf8d7a35766efebb97e304d4bd5d7f3f6b  LICENSE
 3eb823230e5d112e1bd032ccc82ae765cf676d0d6d46a1a1daa2d658b3005b67  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4  vendor/github.com/modern-go/concurrent/LICENSE
 c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4  vendor/github.com/modern-go/reflect2/LICENSE

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -12,39 +12,74 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//go:build main
+// +build main
+
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"flag"
+	"fmt"
+	"hash/crc64"
+	"io"
 	"os"
+	"os/signal"
 	"testing"
-)
 
-var (
-	acceptanceTesting bool
+	"github.com/mendersoftware/go-lib-micro/log"
 )
 
 func init() {
-	flag.BoolVar(&acceptanceTesting, "acceptance-testing", false,
-		"Acceptance testing mode, starts the application main function "+
-			"with cover mode enabled. Non-flag arguments are passed"+
-			"to the main application, add '--' after test flags to"+
-			"pass flags to main.",
-	)
+	// Make sure main does not exit before we have gathered coverage.
+	log.Log.ExitFunc = func(int) {}
 }
+
+const (
+	coverName = "coverage-acceptance"
+	coverExt  = ".txt"
+)
+
+var stdout = os.Stdout
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	if acceptanceTesting {
-		// Override 'run' flags to only execute TestDoMain
-		flag.Set("test.run", "TestDoMain")
+	argHash := crc64.New(crc64.MakeTable(crc64.ECMA))
+	for _, arg := range os.Args {
+		_, _ = argHash.Write([]byte(arg))
 	}
-	os.Exit(m.Run())
+	var b [6]byte
+	_, err := io.ReadFull(rand.Reader, b[:])
+	if err != nil {
+		panic(err)
+	}
+	// filename = "{coverName}@{hash(args)}-{48-bit rand}.txt"
+	fileNameCover := fmt.Sprintf("%s@%s-%s%s",
+		coverName,
+		hex.EncodeToString(argHash.Sum(nil)),
+		hex.EncodeToString(b[:]),
+		coverExt,
+	)
+
+	// Override arguments passed to "testing" package
+	os.Args = os.Args[:1]
+	flag.Set("test.run", "TestRunMain")
+	flag.Set("test.coverprofile", fileNameCover)
+
+	// Run tests
+	exitCode := m.Run()
+	os.Stdout = stdout
+	os.Exit(exitCode)
 }
 
-func TestDoMain(t *testing.T) {
-	if !acceptanceTesting {
-		t.Skip()
-	}
-	doMain(append(os.Args[:1], flag.Args()...))
+func TestRunMain(t *testing.T) {
+	stopChan := make(chan os.Signal, 1)
+	signal.Notify(stopChan, os.Interrupt)
+	go func() {
+		doMain(os.Args[:cap(os.Args)])
+		stopChan <- os.Interrupt
+	}()
+	<-stopChan
+	// Prevent the output from testing to hit stdout
+	os.Stdout = os.Stderr
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,14 +1,16 @@
 version: '2.1'
 services:
 
-    acceptance:
+    tester:
         image: mendersoftware/mender-test-containers:acceptance-testing
         networks:
             - mender
         volumes:
             - ".:/testing"
+            - "/var/run/docker.sock:/var/run/docker.sock"
         depends_on:
             - mender-deviceconfig
+            - mender-mongo
             - mmock
 
     mender-deviceconfig:
@@ -22,6 +24,7 @@ services:
             - mender-deviceconfig
       volumes:
         - ".:/testing"
+      working_dir: /testing
       depends_on:
         - mender-mongo
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,8 +9,6 @@ export TESTING_MMOCK_HOST=${TESTING_MMOCK_HOST:="mmock:8080"}
 
 export PYTHONDONTWRITEBYTECODE=1
 
-pip3 install --quiet --force-reinstall -r /testing/requirements.txt
-
 # if we're running in a container, wait a little before starting tests
 [ $$ -eq 1 ] && sleep 10
 


### PR DESCRIPTION
This commit does not introduce any practical change to the acceptance
tests coverage itself, but aligns the environment with the rest of the
backend services.