### PR TITLE
chore: bump golang from 1.19.3-alpine3.16 to 1.20.1-alpine3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.16 as builder
+FROM golang:1.20.1-alpine3.16 as builder
 WORKDIR /go/src/github.com/mendersoftware/deviceconfig
 RUN mkdir -p /etc_extra
 RUN echo "nobody:x:65534:" > /etc_extra/group

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.16 as builder
+FROM golang:1.20.1-alpine3.16 as builder
 WORKDIR /go/src/github.com/mendersoftware/deviceconfig
 RUN mkdir -p /etc_extra
 RUN echo "nobody:x:65534:" > /etc_extra/group


### PR DESCRIPTION
Bumps golang from 1.19.3-alpine3.16 to 1.20.1-alpine3.16.

---
updated-dependencies:
- dependency-name: golang dependency-type: direct:production update-type: version-update:semver-minor ...