### PR TITLE
chore: enable api docs linter as obligatory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,3 +102,5 @@ publish:image:mender:
   rules:
     - when: never
 
+test:validate-open-api:
+  allow_failure: false


### PR DESCRIPTION
Ticket: None