### PR TITLE
ci: move from public to self-hosted runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ test:acceptance:
   except:
     - /^saas-[a-zA-Z0-9.-]+$/
   tags:
-    - docker
+    - hetzner-amd-beefy
   image: docker:20.10.21
   services:
     - name: docker:20.10.21-dind


### PR DESCRIPTION
Public runners are considered not secure; moving to self-hosted runners instead.

Ticket: SEC-1133
Changelog: None