### PR TITLE
Update golang version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,9 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
 
+.dind-login: &dind-login
+  - mkdir -p $HOME/.docker && echo $DOCKER_AUTH_CONFIG > $HOME/.docker/config.json
+
 test:acceptance:
   stage: test
   needs: []
@@ -37,12 +40,13 @@ test:acceptance:
     - /^saas-[a-zA-Z0-9.-]+$/
   tags:
     - hetzner-amd-beefy
-  image: docker:20.10.21
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:20.10.21
   services:
     - name: docker:20.10.21-dind
       alias: docker
   before_script:
     - apk add docker-compose make
+    - *dind-login
   script:
     - make acceptance-tests
   after_script:
@@ -63,7 +67,7 @@ publish:acceptance:
   stage: publish
   except:
     - /^saas-[a-zA-Z0-9.-]+$/
-  image: golang:1.22
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:1.22
   needs:
     - job: test:acceptance
       artifacts: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,12 +63,13 @@ publish:acceptance:
   stage: publish
   except:
     - /^saas-[a-zA-Z0-9.-]+$/
-  image: golang:1.17
+  image: golang:1.22
   needs:
     - job: test:acceptance
       artifacts: true
   before_script:
-    - GO111MODULE=off go get github.com/mattn/goveralls
+    - go get github.com/mattn/goveralls
+    - go install github.com/mattn/goveralls
     # Coveralls env variables:
     #  According to https://docs.coveralls.io/supported-ci-services
     #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according


### PR DESCRIPTION
The newer golang version from this commit is needed for `publish:acceptance`

```$ GO111MODULE=off go get github.com/mattn/goveralls
# golang.org/x/mod/modfile
/go/src/golang.org/x/mod/modfile/rule.go:437:21: undefined: strings.Cut
/go/src/golang.org/x/mod/modfile/rule.go:710:21: undefined: strings.Cut
```

